### PR TITLE
Update build-dashboard.yml

### DIFF
--- a/.github/workflows/build-dashboard.yml
+++ b/.github/workflows/build-dashboard.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.10'
     - name: Collect dashboard data
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use python 3.10

## Summary by Sourcery

CI:
- Specify exact Python 3.10 version in build dashboard workflow