### PR TITLE
Fix collect.py script to use correct method for listing milestones

### DIFF
--- a/docs/scripts/collect.py
+++ b/docs/scripts/collect.py
@@ -62,7 +62,7 @@ def main():
         )
 
     # Milestones
-    ms = api.repos.list_milestones_for_repo(state="all", per_page=10)
+    ms = api.issues.list_milestones(state="all", per_page=10)
     milestones = []
     milestones.extend(
         {


### PR DESCRIPTION
Fixes #39

Update `docs/scripts/collect.py` to use the correct method for listing milestones.

* Replace the incorrect method `api.repos.list_milestones_for_repo(state="all", per_page=10)` with the correct method `api.issues.list_milestones(state="all", per_page=10)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fnfontana/musical-map-project/pull/40?shareId=1362e7bc-f3ff-4df5-9711-8165f5292018).

## Summary by Sourcery

Bug Fixes:
- Corrected the GitHub API method from `list_milestones_for_repo` to `list_milestones` to properly retrieve milestones